### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Cordova-CallLog-Plugin
 
 Android only (help with IOS welcome) cordova plugin to access the call history on a device.
 
-Installation 
+Installation
 ============
-  cordova plugins add "https://github.com/uriva/CallLogPlugin"
+  cordova plugins add "https://github.com/dalyc/Cordova-CallLog-Plugin"
 
 Usage
 =====


### PR DESCRIPTION
Old plugin link - https://github.com/uriva/CallLogPlugin throws 404 Error.

Changed it to the current link of the repository.

:fireworks: